### PR TITLE
Removing whitespace fixed the error!

### DIFF
--- a/src/command/tz.jl
+++ b/src/command/tz.jl
@@ -13,7 +13,7 @@ DATE_TIME_PATTERNS = (
 function time_zone_commander(c::Client, m::Message)
     # @info "time_zone_commander called"
     # @info "Message content" m.content m.author.username m.author.discriminator
-    startswith(m.content, COMMAND_PREFIX * "tz ") || return
+    startswith(m.content, COMMAND_PREFIX * "tz") || return
     regex = Regex(COMMAND_PREFIX * raw"tz (help|convert|aliases) *(.*)$")
     matches = match(regex, m.content)
     if matches === nothing || matches.captures[1] == "help"


### PR DESCRIPTION
the multiplication done to the string expects a white space ...but i think discord removes that
so just removing a whitespace made it go from ",tz " to ",tz" which as far as i have tested works!

p.s: this is a tiny pull request :sweat_smile: :sweat_smile: 