### PR TITLE
fix and improve Discord.split_message

### DIFF
--- a/src/command/j.jl
+++ b/src/command/j.jl
@@ -1,6 +1,67 @@
 # implement julia_commander
 # for the moment, only help is implemented
 
+function filterranges(u::Vector{UnitRange{Int}})
+    v = Vector{Int}()
+    while length(u) > 1
+        if all(m -> (u[1] ⊈ m), u[2:end])
+            push!(v, u[1][end])
+        end
+        u = u[findall(m -> m ⊈ u[1], u[2:end]).+1]
+    end
+    if length(u) == 1
+        push!(v,u[1][end])
+    end
+    return v
+end
+
+const STYLES = [
+    r"```.+?```"s, r"`.+?`", r"~~.+?~~", r"_.+?_", r"__.+?__",
+    r"\*.+?\*", r"\*\*.+?\*\*", r"\*\*\*.+?\*\*\*",
+]
+
+function split_message_fixed(text::AbstractString, chunk_limit::Int=2000; extraregex::Vector{Regex}=Vector{Regex}())
+    length(text) <= chunk_limit && return String[text]
+    chunks = String[]
+
+    while !isempty(text)
+        mranges = vcat(findall.(union(STYLES,extraregex),Ref(text))...)
+        
+        stop = maximum(filter(i -> length(text[1:i]) ≤ chunk_limit, filterranges(mranges)))
+
+        # give up if first chunk cannot be broken down
+        if stop == 0
+            push!(chunks, strip(text))
+            @warn "message could not be broken down into chunks smaller than the desired length $chunk_limit"
+            return chunks
+        end
+
+        push!(chunks, strip(text[1:stop]))
+        text = strip(text[stop+1:end])
+    end
+
+    return chunks
+end
+
+function parse_doc!(doc::AbstractString)
+    doc = replace(doc, r"\n\n\n+" => "\n\n")
+    for m in eachmatch(r"(^|\n)(#+ |!!! )(.*)\n",doc)
+        if m.captures[2] == "# "
+            doc = replace(doc, m.match => m.captures[1]*"**"*m.captures[3]*"**\n"*"≡"^(length(m.captures[3])), count = 1)
+        elseif m.captures[2] == "!!! "
+            doc = replace(doc, m.match => m.captures[1]*"__"*m.captures[3]*"__\n", count = 1)
+        else
+            doc = replace(doc, m.match => m.captures[1]*"*"*m.captures[3]*"*\n"*"-"^(length(m.captures[3])), count = 1)
+        end
+    end
+    doc = replace(doc, r"(```.+)\n" => "```julia\n")
+    doc = replace(doc, "```\n" => "```")
+    for m in eachmatch(r"\[([^ ]*)\]\(@ref\)",doc)
+        doc = replace(doc, m.match => "`"*m.captures[1]*"`", count = 1)
+    end
+    return doc
+end
+
 function julia_commander(c::Client, m::Message)
     # @info "julia_commander called"
     # @info "Message content" m.content m.author.username m.author.discriminator
@@ -41,31 +102,10 @@ function handle_julia_help_commander(c::Client, m::Message, name::AbstractString
     else
         try
             doc = string(eval(Meta.parse("Docs.@doc("*name*")")))
-            doc = replace(doc, r"\n\n\n+" => "\n\n")
-            for m in eachmatch(r"(^|\n)(#+ |!!! )(.*)\n",doc)
-                if m.captures[2] == "# "
-                    doc = replace(doc, m.match => m.captures[1]*"*"*m.captures[3]*"*\n"*"≡"^(length(m.captures[3])), count = 1)
-                elseif m.captures[2] == "!!! "
-                    doc = replace(doc, m.match => m.captures[1]*"__"*m.captures[3]*"__\n", count = 1)
-                else
-                    doc = replace(doc, m.match => m.captures[1]*"**"*m.captures[3]*"**\n"*"≡"^(length(m.captures[3])), count = 1)
-                end
-            end
-            doc = replace(doc, r"(```.+)\n" => "```julia\n")
-            doc = replace(doc, "```\n" => "```")
-            for m in eachmatch(r"\[([^ ]*)\]\(@ref\)",doc)
-                doc = replace(doc, m.match => "`"*m.captures[1]*"`", count = 1)
-            end
-            docs = split_message(doc)
-            i = 1
-            while i ≤ length(docs)
-                if length(prod(docs[i:end])) ≤ 2000
-                    reply(c, m, prod(docs[i:end]))
-                    i = length(docs) + 1
-                else
-                    reply(c, m, docs[i])
-                    i += 1
-                end             
+            doc = parse_doc!(doc)
+            docs = split_message_fixed(doc, extraregex = [r"\n≡.+\n", r"n-.+\n"])
+            for doc_chunck in docs
+                reply(c, m, doc_chunck)
             end
         catch ex
             @show ex


### PR DESCRIPTION
- Fix unicode indexing
- Fix handling nested formatting
- Fix backtracking to a valid index
- Add optional argument to vary the length limit of the chunks, which were hardcoded to Discord's 2000 limit
- Add optional argument to include extra regex to prevent from being splitted
