### PR TITLE
Add whistle blower handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-audit/*
 data/*
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+audit/*
 data/*
+.DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Discord = "fcbf000d-02fd-53f1-af91-d952191673d3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 TimeZones = "1.5"

--- a/src/HoJBot.jl
+++ b/src/HoJBot.jl
@@ -7,14 +7,17 @@ using Dates
 using JSON
 using OrderedCollections
 using TimeZones
+using UUIDs
 
 const COMMAND_PREFIX = ","
 
+include("util.jl")
 include("main.jl")
 include("command/tz.jl")
 include("command/j.jl")
 include("command/gm.jl")
 include("command/react.jl")
 include("handler/reaction.jl")
+include("handler/whistle.jl")
 
 end # module

--- a/src/handler/whistle.jl
+++ b/src/handler/whistle.jl
@@ -1,0 +1,76 @@
+# Whistle blower - complain about inappropriate content
+
+struct WhistleBlower
+    user_id::UInt64
+    message_id::UInt64
+end
+
+# In-memory cache that keeps track of how many whistle blower reports
+# for the message.
+#   Key: message_id
+#   Value: count of whistle blower reports
+const WHISTLE_REPORTS_COUNT = Dict{UInt64,UInt64}()
+
+# Keep track of how which messages a whistle blower has reported
+#   Key: user_id
+#   Value: Set of message_id
+const WHISTLE_REPORTS = Dict{UInt64,Set{UInt64}}()
+
+# How many reports needs to be received before the message should
+# be deleted.
+const REMOVE_MESSAGE_MIN_REPORTS = 3
+
+# Emoji used to trigger a whistle blower report
+const WHISTLE_EMOJI = "🚷"
+
+const WHISTLE_BLOWER_THANK_YOU_MESSAGE = remove_newline("""
+    Thank you for your whistle blower report. The message with potentially
+    inappropriate content will be removed automatically once we receive
+    enough reports. Please direct any questions to the @Moderator team.
+    """)
+
+# Handler
+function handler(c::Client, e::MessageReactionAdd, ::Val{:whistle})
+    @info "MessageReactionAdd" e.user_id e.channel_id e.message_id e.emoji
+
+    # Find previous reports by this user
+    prior_user_reports = get!(WHISTLE_REPORTS, e.user_id, Set{UInt64}())
+
+    # If emoji matches
+    if e.emoji.name === WHISTLE_EMOJI
+
+        # Increment counter
+        count = get!(WHISTLE_REPORTS_COUNT, e.message_id, 0)
+        if e.message_id ∉ prior_user_reports  # do not over-count
+            count += 1
+        end
+        WHISTLE_REPORTS_COUNT[e.message_id] = count
+
+        if count >= REMOVE_MESSAGE_MIN_REPORTS
+            @info "Max reports reached" e.user_id e.channel_id e.message_id
+            # delete the message
+            m = Message(; id = e.message_id, channel_id = e.channel_id)
+            @discord delete(c, m)
+        else
+            # remove the emoji to protect reporter's identity
+            m = Message(; id = e.message_id, channel_id = e.channel_id)
+            u = User(; id = e.user_id)
+            @discord delete(c, e.emoji, m, u)
+        end
+
+        # thank reporter
+        dm_channel = fetchval(create_dm(c; recipient_id = e.user_id))
+        uuid = string(uuid4())[end-11:end]
+        reference = " (Reference ID: $uuid)"
+        @discord create(c, Message, dm_channel;
+            content = WHISTLE_BLOWER_THANK_YOU_MESSAGE)
+
+        # remember this report
+        push!(prior_user_reports, e.message_id)
+
+        # log an audit event
+        user = @discord retrieve(c, User, e.user_id)
+        audit(user.id, user.username, user.discriminator,
+            "whistle report against message $(e.message_id) ref=$uuid cnt=$count")
+    end
+end

--- a/src/main.jl
+++ b/src/main.jl
@@ -12,9 +12,10 @@ const commands_names = LittleDict([
     :tz => :time_zone
 ])
 
-const handlers_list = LittleDict([
-    :reaction => true,
-])
+const handlers_list = [
+    (:reaction, MessageCreate, true),
+    (:whistle, MessageReactionAdd, true),
+]
 
 const opt_services_list = [
     :game_master,
@@ -55,8 +56,8 @@ function start_bot(;
 end
 
 function init_handlers!(client::Client, handlers)
-    for (hand, active) in handlers
-        active && add_handler!(client, MessageCreate, (c, e) -> handler(c, e, hand))
+    for (symbol, event, active) in handlers
+        active && add_handler!(client, event, (c, e) -> handler(c, e, Val(symbol)))
     end
 end
 
@@ -66,10 +67,6 @@ function init_commands!(client::Client, commands)
     end
 end
 
-handler(c::Client, e::MessageCreate, hand) = begin
-    @info "handler" c e hand
-    handler(c, e, Val(hand))
-end
 commander(c::Client, m::Message, service) =
 begin
     @info "commander" c m service

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,8 +1,14 @@
-
 function remove_newline(s::AbstractString)
     return replace(s, r"\n" => " ")
 end
 
+"""
+    @discord(ex)
+
+Evaluate any Discord.jl function that is expected to return a future.
+The response is captured and logged at Debug level before the
+underlying value is returned.
+"""
 macro discord(ex)
     return quote
         future = $(esc(ex))
@@ -12,17 +18,30 @@ macro discord(ex)
     end
 end
 
-# A poor-man's way to write audit log
+"""
+    audit(source, user_id, name, discriminator, message; audit_dir, audit_file)
+
+Create an audit record in the system for a given event.
+
+# Arguments
+- `source`: unique string representing where the audit log comes from
+- `user_id`: Discord user id
+- `name`: Discord user name
+- `discriminator`: Discord user discriminator
+- `audit_dir`: audit log directory, defaults to `data/audit`
+- `audit_file`: audit log file, defaults to `\$audit_dir/\$source.log`
+"""
 function audit(
+    source::AbstractString,
     user_id::UInt64,
     name::AbstractString,
     discriminator::AbstractString,
     message::AbstractString;
-    audit_dir = "audit",
-    audit_file = "audit.log"
+    audit_dir = joinpath("data", "audit"),
+    audit_file = joinpath(audit_dir, "$source.log")
 )
-    isdir(audit_dir) || mkdir(audit_dir)
-    open(joinpath(audit_dir, audit_file); write = true, append = true) do io
-        println(io, "$(now(tz"UTC")) $name#$discriminator ($user_id) $message")
+    mkpath(audit_dir)
+    open(joinpath(audit_file); write = true, append = true) do io
+        println(io, "$(now(tz"UTC"))\t$name#$discriminator\t$user_id\t$message")
     end
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,0 +1,28 @@
+
+function remove_newline(s::AbstractString)
+    return replace(s, r"\n" => " ")
+end
+
+macro discord(ex)
+    return quote
+        future = $(esc(ex))
+        response = fetch(future)
+        @debug "Response received" response
+        response.val
+    end
+end
+
+# A poor-man's way to write audit log
+function audit(
+    user_id::UInt64,
+    name::AbstractString,
+    discriminator::AbstractString,
+    message::AbstractString;
+    audit_dir = "audit",
+    audit_file = "audit.log"
+)
+    isdir(audit_dir) || mkdir(audit_dir)
+    open(joinpath(audit_dir, audit_file); write = true, append = true) do io
+        println(io, "$(now(tz"UTC")) $name#$discriminator ($user_id) $message")
+    end
+end


### PR DESCRIPTION
Resolves #34 

Couple notes: 
1. For now, I am using the 🚷 emoji for people to report inappropriate content. It is possible to use a custom emoji if necessary. 
1. The threshold that triggers a message removal is 3.  Is that too loose or too tight? Please comment below.
1. The emoji is automatically removed immediately to protect the reporter's identity
1. A DM message is sent to the reporter, thanking their action.
1. A user can only report against the same once.

The bot should also alert Mod team & DM the member who is potentially in violation. I haven't done these yet... That should be fairly straightforward to do.
