### PR TITLE
Allow command prefix to be overridden by env variable

### DIFF
--- a/src/HoJBot.jl
+++ b/src/HoJBot.jl
@@ -8,7 +8,7 @@ using JSON
 using OrderedCollections
 using TimeZones
 
-const COMMAND_PREFIX = ","
+const COMMAND_PREFIX = get(ENV, "HOJBOT_COMMAND_PREFIX", ",")
 
 include("main.jl")
 include("command/tz.jl")


### PR DESCRIPTION
Useful for development purpose. Just set `HOJBOT_COMMAND_PREFIX` environment variable if you wish to use a different prefix.