### PR TITLE
Auto shutdown and restart bot periodically

### DIFF
--- a/script/run.sh
+++ b/script/run.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
+# Start the HoJBot program
 
 if [[ -z "$HOJBOT_DISCORD_TOKEN" ]]; then
     echo "Error: please set up HOJBOT_DISCORD_TOKEN environment variable"
     exit 1
 fi
 
-julia --project=. -e 'using HoJBot; start_bot();'
+# Default environment settings
+: ${RUN_ONCE=no}
+: ${RUN_DURATION_MINUTES=360}
+
+while true; do
+    echo "`date`: Starting HoJBot..."
+    julia --project=. -e "using HoJBot, Dates; start_bot(; run_duration = Minute(${RUN_DURATION_MINUTES}));"
+    if [[ "$RUN_ONCE" == "yes" ]]; then
+        break
+    fi
+    sleep 1  # throttle to avoid a hot loop when the process keep crashing
+done
+echo "`date`: Program exited normally"

--- a/src/main.jl
+++ b/src/main.jl
@@ -47,6 +47,7 @@ end
 function start_bot(;
     commands = active_commands,
     handlers = handlers_list,
+    run_duration = Days(365),  # run for a very long time by default
 )
     @info "Starting bot... command prefix = $COMMAND_PREFIX"
     global client = Client(ENV["HOJBOT_DISCORD_TOKEN"];
@@ -56,6 +57,7 @@ function start_bot(;
     init_commands!(client, commands)
     # add_help!(client; help = help_message())
     open(client)
+    auto_shutdown(run_duration)
     wait(client)
 end
 
@@ -68,6 +70,23 @@ end
 function init_commands!(client::Client, commands)
     for (com, active) in commands
         active && add_command!(client, com, (c, m) -> commander(c, m, commands_names[com]))
+    end
+end
+
+"""
+    auto_shutdown(run_duration::TimePeriod)
+
+Run a background process to track the program's run time and exit
+the program when it has exceeded the specified `run_duration`.
+"""
+function auto_shutdown(run_duration::TimePeriod)
+    start_time = now()
+    @async while true
+        if now() > start_time + run_duration
+            @info "Times up! The bot is shutting down automatically."
+            exit(0)
+        end
+        sleep(5)
     end
 end
 


### PR DESCRIPTION
Resolves #50 

Here's the current design:
- `start_bot` function now takes a kwarg `run_duration`
- The new `auto_shutdown` function spawns an async task to keep track of time
- When current time exceeds `start_time` + `run_duration` then it just exits program
- The run.sh script has a loop that runs forever, unless `RUN_ONCE` environment variable is set to `yes`
- The run.sh script also accepts an environment variable `RUN_DURATION_MINUTES` which is set to 6 hours by default

Note that this is a simple design and not super-robust. For example, if there's a transaction happening (e.g. writing to a JSON file for some command) and the program exits abruptly then we may have a corrupted file. Given the current traffic, I don't think this is a big issue at the moment. We can fix that later if the bot is used more heavily.