### PR TITLE
Investment game - bug fix and ability to disable warm up

### DIFF
--- a/src/command/ig.jl
+++ b/src/command/ig.jl
@@ -345,7 +345,7 @@ end
     data = JSON3.read(response.body)
     current_price = data.c
     current_price > 0 || throw(IgUserError("there is no price for $symbol. Is it a valid stock symbol?"))
-    current_price
+    return Float64(current_price)
 end
 
 "Fetch quote of a stock, but possibly with a time delay."

--- a/src/main.jl
+++ b/src/main.jl
@@ -68,7 +68,7 @@ function start_bot(;
     init_handlers!(client, handlers)
     init_commands!(client, commands)
     # add_help!(client; help = help_message())
-    warm_up()
+    warm_up_enabled() && warm_up()
     open(client)
     auto_shutdown(client, run_duration, "SHUTDOWN")
     wait(client)
@@ -193,6 +193,10 @@ function opt_out(c::Client, m::Message, service)
             """
         )
     end
+end
+
+function warm_up_enabled()
+    return get(ENV, "ENABLE_WARM_UP", "1") in ("1", "Y", "YES")
 end
 
 # TODO use SnoopCompile to find precompile methods


### PR DESCRIPTION
Two things:
1. Fixed a type stability bug - when fetching stock quote it may be parsed as a `Float64` or `Int` from the JSON string.
2. The warm-up process during start-up can be disabled now. It would be useful for bot developers who don't care about investment game or don't want to wait for the longer startup time.

To disable the warm up process, start the process like this:
```
ENABLE_WARM_UP=0 script/run.sh
```