### PR TITLE
Investment game - gain loss & hist commands

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -193,3 +193,6 @@ function extract_command(command::AbstractString, s::AbstractString)
     prefix = COMMAND_PREFIX * command
     return strip(replace(s, Regex("^" * prefix * " *") => ""))
 end
+
+# TODO move to constants.jl later
+const Optional{T} = Union{T, Nothing}


### PR DESCRIPTION
Resolves #62. Only the long form is implemented. Let's work on the short form later if people really want that.
![image](https://user-images.githubusercontent.com/1159782/116788324-ce044980-aa5d-11eb-91d6-3f4d721b6739.png)

Also add a new `ig hist` command for displaying purchase history. It takes the forms of:
- `ig hist` for all holdings
- `ig hist <symbol>` for a specific stock

![image](https://user-images.githubusercontent.com/1159782/116788340-db213880-aa5d-11eb-90da-e093b2caa857.png)

![image](https://user-images.githubusercontent.com/1159782/116788346-e96f5480-aa5d-11eb-8d25-402fe52b59f4.png)


