### PR TITLE
Handle null data when retrieving quote from Yahoo Finance

### DIFF
--- a/src/command/ig.jl
+++ b/src/command/ig.jl
@@ -653,7 +653,8 @@ function ig_historical_prices(symbol::AbstractString, from_date::Date, to_date::
     url = "https://query1.finance.yahoo.com/v7/finance/download/$symbol?" *
         "period1=$from_sec&period2=$to_sec&interval=1d&events=history&includeAdjustedClose=true"
     try
-        elapsed = @elapsed df = DataFrame(CSV.File(Downloads.download(url)))
+        elapsed = @elapsed df = DataFrame(CSV.File(Downloads.download(url); missingstring="null"))
+        dropmissing!(df)
         @info "$(now())\tig_historical_prices\t$symbol\t$from_date\t$to_date\t$elapsed"
         return df
     catch ex


### PR DESCRIPTION
Sometimes Yahoo Finance would return data with null's. This commit ensures that "null" string is recognized as missing when `ig_historical_prices` is called. Then, missing data is excluded before returning the result.

For example:

```
Date,Open,High,Low,Close,Adj Close,Volume
2021-05-10,0.569687,0.569687,0.421291,0.449964,0.449964,16514521828
2021-05-11,0.450488,0.546651,0.445034,0.495231,0.495231,14566975476
2021-05-12,0.493742,0.519975,0.385376,0.385376,0.385376,8621337859
2021-05-13,0.392176,0.519461,0.357175,0.490374,0.490374,18663174069
2021-05-14,null,null,null,null,null,null
2021-05-15,0.494861,0.586298,0.467698,0.562172,0.562172,20718891008
```