### PR TITLE
Automatically hide bad words and updated bad word list

### DIFF
--- a/config/mod/bad-words.txt
+++ b/config/mod/bad-words.txt
@@ -56,9 +56,9 @@ b1tch
 babe
 babes
 ballsack
--bang
+bang
 banger
-?barf
+barf
 bastard
 bastards
 bawdy
@@ -68,7 +68,6 @@ beastiality
 beatch
 beater
 beaver
-?beer
 beeyotch
 beotch
 biatch
@@ -80,7 +79,7 @@ bitched
 bitches
 bitchy
 blow job
-?blow
+blow
 blowjob
 blowjobs
 bod
@@ -89,7 +88,7 @@ boink
 bollock
 bollocks
 bollok
-?bone
+bone
 boned
 boner
 boners
@@ -110,19 +109,16 @@ bosom
 bosomy
 bowel
 bowels
--bra
+bra
 brassiere
-?breast
-?breasts
+breast
+breasts
 bugger
 bukkake
--bullshit
--bullshits
-bullshitted
 bullturds
 bung
 busty
-?butt
+butt
 butt fuck
 buttfuck
 buttfucker
@@ -170,11 +166,8 @@ coon
 coons
 corksucker
 crabs
-crack
 cracker
 crackwhore
-?crap
-?crappy
 cum
 cummin
 cumming
@@ -201,10 +194,6 @@ d1ld0
 d1ldo
 dago
 dagos
-?dammit
-?damn
-?damned
-?damnit
 dawgie-style
 dick
 dickbag
@@ -240,7 +229,7 @@ douche
 douchebag
 douchebags
 douchey
--drunk
+drunk
 dumass
 dumbass
 dumbasses
@@ -272,7 +261,6 @@ faigt
 fannybandit
 fart
 fartknocker
--fat
 felch
 felcher
 felching
@@ -318,8 +306,6 @@ fxck
 gae
 gai
 ganja
-gay
-gays
 gey
 gfy
 ghay
@@ -349,7 +335,6 @@ hard on
 he11
 hebe
 heeb
-hell
 hemp
 heroin
 herp
@@ -399,7 +384,6 @@ junkie
 junky
 kike
 kikes
-?kill
 kinky
 kkk
 klan
@@ -412,7 +396,6 @@ kyke
 labia
 lech
 leper
-lesbians
 lesbo
 lesbos
 lez
@@ -423,8 +406,6 @@ lezbos
 lezzie
 lezzies
 lezzy
-lmao
-lmfao
 loin
 loins
 lube
@@ -593,8 +574,6 @@ scag
 scantily
 schizo
 schlong
-screw
-screwed
 scrog
 scrot
 scrote
@@ -607,11 +586,7 @@ seduce
 semen
 sex
 sexual
-sh1t
-s-h-1-t
 shamedame
-shit
-s-h-i-t
 shite
 shiteater
 shitface
@@ -622,7 +597,6 @@ shits
 shitt
 shitted
 shitter
-shitty
 shiz
 sissy
 skag
@@ -638,7 +612,7 @@ smegma
 smut
 smutty
 snatch
-?sniper
+sniper
 snuff
 s-o-b
 sodom
@@ -655,9 +629,7 @@ steamy
 stfu
 stiffy
 stoned
-strip
 stroke
--stupid
 suck
 sucked
 sucking
@@ -696,7 +668,6 @@ turd
 tush
 twat
 twats
--ugly
 undies
 unwed
 urinal

--- a/config/mod/bad-words.txt
+++ b/config/mod/bad-words.txt
@@ -468,7 +468,7 @@ opiate
 opium
 oral
 orally
-organ
+-organ
 orgasm
 orgasmic
 orgies

--- a/config/mod/bad-words.txt
+++ b/config/mod/bad-words.txt
@@ -332,7 +332,6 @@ h0m0
 h0mo
 handjob
 hard on
-he11
 hebe
 heeb
 hemp
@@ -630,7 +629,6 @@ stfu
 stiffy
 stoned
 stroke
-suck
 sucked
 sucking
 sumofabiatch

--- a/config/mod/bad-words.txt
+++ b/config/mod/bad-words.txt
@@ -56,7 +56,7 @@ b1tch
 babe
 babes
 ballsack
-?bang
+-bang
 banger
 ?barf
 bastard
@@ -110,19 +110,19 @@ bosom
 bosomy
 bowel
 bowels
-bra
+-bra
 brassiere
-breast
-breasts
+?breast
+?breasts
 bugger
 bukkake
-bullshit
-bullshits
+-bullshit
+-bullshits
 bullshitted
 bullturds
 bung
 busty
-butt
+?butt
 butt fuck
 buttfuck
 buttfucker
@@ -201,10 +201,10 @@ d1ld0
 d1ldo
 dago
 dagos
-dammit
-damn
-damned
-damnit
+?dammit
+?damn
+?damned
+?damnit
 dawgie-style
 dick
 dickbag
@@ -240,7 +240,7 @@ douche
 douchebag
 douchebags
 douchey
-?drunk
+-drunk
 dumass
 dumbass
 dumbasses
@@ -272,7 +272,7 @@ faigt
 fannybandit
 fart
 fartknocker
-?fat
+-fat
 felch
 felcher
 felching
@@ -657,7 +657,7 @@ stiffy
 stoned
 strip
 stroke
-stupid
+-stupid
 suck
 sucked
 sucking
@@ -696,7 +696,7 @@ turd
 tush
 twat
 twats
-ugly
+-ugly
 undies
 unwed
 urinal

--- a/src/HoJBot.jl
+++ b/src/HoJBot.jl
@@ -38,6 +38,8 @@ include("command/src.jl")
 
 include("handler/reaction.jl")
 include("handler/whistle.jl")
+
+include("type/mod.jl")
 include("handler/mod.jl")
 
 include("type/discourse.jl")

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -24,6 +24,7 @@ const COMMANDS_NAMES = LittleDict([
 const HANDLERS_LIST = [
     (:discourse, MessageReactionAdd, true),
     (:mod,       MessageCreate,      true),
+    (:mod,       MessageUpdate,      true),
     (:reaction,  MessageCreate,      true),
     (:whistle,   MessageReactionAdd, true),
 ]

--- a/src/handler/mod.jl
+++ b/src/handler/mod.jl
@@ -1,10 +1,12 @@
 const MOD_REPORT_CHANNEL_NAME = "mod-report"
 const MOD_REPORT_CHANNEL = Ref{DiscordChannel}()
-const BAD_WORDS = Vector{String}()
+const BAD_WORDS = String[]
 
-function handler(c::Client, e::MessageCreate, ::Val{:mod})
-    # @info "mod handler: $(e.message.content)"
-
+function handler(
+    c::Client, 
+    e::Union{MessageCreate, MessageUpdate}, 
+    ::Val{:mod}
+)
     mod_report_channel = mod_get_report_channel(c, e.message.guild_id)
     if mod_report_channel === nothing
         return # config error; nothing we can do about...
@@ -94,6 +96,11 @@ function mod_check(content::AbstractString)
     return (:good, "")
 end
 
+"""
+    mod_report
+
+Return a string about the issue that will be sent to the mod-report channel.
+"""
 function mod_report(
     username::AbstractString,
     content::AbstractString,

--- a/src/handler/mod.jl
+++ b/src/handler/mod.jl
@@ -29,17 +29,20 @@ function handler(
     result = mod_check_message(e.message.content)
     if !isempty(result)
         user_id = e.message.author.id
-        # Update the mod-report channel
-        report = mod_report(user_id, e.message.content, result,
-            e.message.id, e.message.channel_id, e.message.guild_id)
-        if mod_report_channel !== nothing
-            create_message(c, mod_report_channel.id; content = report)
-        end
+        report_message_id = e.message.id
         # Censor message
         new_content = mod_censor_message(e.message.content, result)
         if new_content != e.message.content
             delete_message(c, e.message.channel_id, e.message.id)
-            create_message(c, e.message.channel_id; content = "<@!$(user_id)> said: $new_content")
+            censored_message = @discord create_message(c, e.message.channel_id;
+                content = "<@!$(user_id)> said: $new_content")
+            report_message_id = censored_message.id
+        end
+        # Update the mod-report channel
+        report = mod_report(user_id, e.message.content, result,
+            report_message_id, e.message.channel_id, e.message.guild_id)
+        if mod_report_channel !== nothing
+            create_message(c, mod_report_channel.id; content = report)
         end
     end
     return nothing

--- a/src/main.jl
+++ b/src/main.jl
@@ -187,24 +187,25 @@ end
 function warm_up()
     @info "Warming up..."
     Threads.@spawn begin
-        dummy_user_id = UInt64(0)
+        # dummy_user_id = UInt64(0)
         elapsed = @elapsed try
             symbol = "AAPL"
             ig_get_quote(symbol)
-            ig_save_portfolio(
-                dummy_user_id, IgPortfolio(100, [IgHolding(symbol, 100, today(), 130)])
-            )
-            ig_load_portfolio(dummy_user_id)
+            # ig_save_portfolio(
+            #     dummy_user_id, IgPortfolio(100, [IgHolding(symbol, 100, today(), 130)])
+            # )
+            # ig_load_portfolio(dummy_user_id)
             ig_ranking_table(Client("hey"))
 
             from_date, to_date = Date(2020, 1, 1), Date(2020, 12, 31)
             df = ig_historical_prices(symbol, from_date, to_date)
+            @info "Warm up: charting"
             ig_chart(symbol, df.Date, df."Adj Close")
         catch ex
             @error "Warm up error: " ex
             Base.showerror(stdout, ex, catch_backtrace())
         finally
-            ig_remove_game(dummy_user_id)
+            # ig_remove_game(dummy_user_id)
         end
         @info "Completed warm up in $elapsed seconds"
     end

--- a/src/type/mod.jl
+++ b/src/type/mod.jl
@@ -1,0 +1,17 @@
+abstract type AbstractBadWord end
+
+struct BadWord <: AbstractBadWord
+    word::String
+end
+
+struct QuestionableWord <: AbstractBadWord
+    word::String
+end
+
+struct OverriddenWord <: AbstractBadWord
+    word::String
+end
+
+function Base.show(io::IO, w::AbstractBadWord)
+    print(io, w.word)
+end

--- a/src/type/mod.jl
+++ b/src/type/mod.jl
@@ -1,17 +1,19 @@
-abstract type AbstractBadWord end
-
-struct BadWord <: AbstractBadWord
+@enum WordClass begin
+    Bad
+    Questionable
+    Overridden
+end
+struct BadWord
+    class::WordClass
     word::String
 end
 
-struct QuestionableWord <: AbstractBadWord
-    word::String
-end
+const WordClassStrings = Dict(
+    Bad => "Bad",
+    Questionable => "Questionable",
+    Overridden => "Overridden",
+)
 
-struct OverriddenWord <: AbstractBadWord
-    word::String
-end
-
-function Base.show(io::IO, w::AbstractBadWord)
-    print(io, w.word)
+function Base.show(io::IO, w::BadWord)
+    print(io, WordClassStrings[w.class], "(", w.word, ")")
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -136,7 +136,7 @@ Update a Discord message with new content.
 """
 function update_message(c::Client, channel_id::UInt64, message_id::UInt64, content::AbstractString)
     message = Message(; id = message_id, channel_id = channel_id)
-    @discord update(c, message; content)
+    return @discord update(c, message; content)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ using Test
     include("test_utils.jl")
     include("test_discourse.jl")
     include("test_ig.jl")
+    include("test_mod.jl")
 end

--- a/test/test_discourse.jl
+++ b/test/test_discourse.jl
@@ -7,7 +7,7 @@ import JSON3
 
 @testset "discourse" begin
 
-    json = discourse_run_query("search.json", "pluto")
+    json = discourse_run_query("search.json", Dict(:q => "pluto"))
 
     let
         @test json isa JSON3.Object
@@ -17,7 +17,10 @@ import JSON3
         @test hasproperty(json.topics[1], :slug)
     end
 
-    let data = DiscourseData(json)
+    let topic_fn = x -> x.topics,
+        make_post_fn = x -> DiscoursePost(x.id, x.slug),
+        data = DiscourseData(topic_fn(json), make_post_fn)
+
         @test length(data) == length(json.topics)
         @test 1 <= data.index <= length(data)
         @test current(data) isa DiscoursePost

--- a/test/test_mod.jl
+++ b/test/test_mod.jl
@@ -1,0 +1,35 @@
+using Test
+using HoJBot: mod_make_regex, mod_check_message
+
+# initialization bad word list since it's lazy
+HoJBot.mod_init()
+
+@testset "mod" begin
+
+    function test_matches(regex, strs, expected)
+        for i in 1:length(strs)
+            @test (match(regex, strs[i]) !== nothing) == expected[i]
+        end         
+    end
+
+    # regular word
+    let regex = mod_make_regex("bad")
+        strs = ["bad", "notbad", "badness"]
+        expected = [true, false, false]
+        test_matches(regex, strs, expected)
+    end
+
+    # having symbols in the match word
+    let regex = mod_make_regex("b.a.d")
+        strs = ["b.a.d", "b1a2d"]
+        expected = [true, false]
+        test_matches(regex, strs, expected)
+    end
+
+    @test isempty(mod_check_message("this is good")) == true
+    @test isempty(mod_check_message("this is shit")) == false
+    @test isempty(mod_check_message("this is ||shit||")) == true
+    @test isempty(mod_check_message("this is damn ||shit||")) == false
+    @test isempty(mod_check_message("this is ok ||shit")) == true
+
+end


### PR DESCRIPTION
If a message contains any bad word, then the message is automatically deleted and the bot sends a new message with the bad words hidden inside spoiler tag. The detection mechanism is unchanged -- the original message is going to be reported in the #mod-report channel.

In addition, the bad words list include 3 main categories:
1. Bad words - majority of the words fall into this category
2. Questionable words - more commonly used words/slangs. These are prefixed with `?`.
3. Overridden words - potentially offensive depending on context. These are prefixed with `-`.

Only bad and questionable words are hidden by the bot automatically. Overridden words still show up in the #mod-report channel in case that a moderator wants to take action.

Finally, if the user already hide a bad word with spoiler tag, then it will not be reported to #mod-report channel.