### PR TITLE
Improve jc

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -81,9 +81,9 @@ version = "1.7.0"
 
 [[DataFrames]]
 deps = ["Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrettyTables", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "1dadfca11c0e08e03ab15b63aaeda55266754bad"
+git-tree-sha1 = "a19645616f37a2c2c3077a44bc0d3e73e13441d7"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.2.0"
+version = "1.2.1"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -323,7 +323,7 @@ uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
 version = "2.36.0+0"
 
 [[LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[Logging]]
@@ -374,6 +374,10 @@ version = "0.3.5"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
 [[OpenTrick]]
 deps = ["Test"]
@@ -628,6 +632,10 @@ version = "1.4.0+3"
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [[libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]

--- a/src/command/jc.jl
+++ b/src/command/jc.jl
@@ -65,7 +65,7 @@ function help_commander(c::Client, m::Message, ::Val{:julia_con})
         ```
         jc help
         jc 2021
-        jc now [timezone]
+        jc now
         jc today [timezone]
         jc tomorrow [timezone]
         jc day <xxxx-mm-dd>

--- a/src/command/jc.jl
+++ b/src/command/jc.jl
@@ -1,6 +1,3 @@
-# TODO: temporary until the start of JuliaCon
-# JuliaCon.debugmode(true)
-
 function commander(c::Client, m::Message, ::Val{:julia_con})
     command = extract_command("jc", m.content)
     args = split(command)
@@ -8,7 +5,7 @@ function commander(c::Client, m::Message, ::Val{:julia_con})
 
     if length(args) == 0 ||
         args[1] ∉ ["2021", "now", "today", "next", "tomorrow", "day"]
-        help_commander(c, m, :jc)
+        help_commander(c, m, :julia_con)
         return
     end
 
@@ -63,8 +60,9 @@ function help_commander(c::Client, m::Message, ::Val{:julia_con})
         ```
         jc help
         jc 2021
-        jc now
-        jc today
+        jc now [timezone]
+        jc today [timezone]
+        jc day <xxxx-mm-dd>
         ```
         `help` prints this message
         `2021` greets the users and provide a link to the official website of year 2021's edition

--- a/src/command/jc.jl
+++ b/src/command/jc.jl
@@ -2,29 +2,60 @@
 # JuliaCon.debugmode(true)
 
 function commander(c::Client, m::Message, ::Val{:julia_con})
-    startswith(m.content, COMMAND_PREFIX * "jc ") ||
-        m.content == COMMAND_PREFIX * "jc" || return
+    command = extract_command("jc", m.content)
+    args = split(command)
+    @debug "parse result" command args
 
-    regex = Regex(COMMAND_PREFIX * raw"jc( help| 2021| now| today)? *(.*)$")
+    if length(args) == 0 ||
+        args[1] ∉ ["2021", "now", "today", "next", "tomorrow", "day"]
+        help_commander(c, m, :jc)
+        return
+    end
 
-    matches = match(regex, m.content)
+    arg = (occursin(r"[0-9]*", args[1]) ? "jc" : "") * args[1]
+    jc_execute(c, m, Symbol(arg), args[2:end])
 
-    if matches === nothing || matches.captures[1] ∈ (" help", nothing)
-        help_commander(c, m, :julia_con)
-    elseif matches.captures[1] == " 2021"
-        @info "2021 was required" m.content m.author.username m.author.discriminator
-        jc_juliacon2021(c, m)
-    elseif matches.captures[1] == " now"
-        @info "now was required" m.content m.author.username m.author.discriminator
-        jc_now(c, m)
-    elseif matches.captures[1] == " today"
-        @info "today was required" m.content m.author.username m.author.discriminator
-        jc_today(c, m)
+end
+
+jc_execute(c, m, arg::Symbol, args) = jc_execute(c, m, Val(arg), args)
+
+function jc_execute(c, m, ::Val{:jc2021}, args)
+    @info "2021 was required" m.content m.author.username m.author.discriminator
+    jc_juliacon2021(c, m)
+end
+
+function jc_execute(c, m, ::Val{:now}, args)
+    @info "now was required" m.content m.author.username m.author.discriminator args
+
+    current = ZonedDateTime(now(), TimeZone(TimeZones.istimezone(args[1]) ? args[1] : "UTC"))
+
+    if JuliaCon.get_running_talks(now = current) === nothing
+        not_now = "There is no JuliaCon program now"
+        @info not_now
+        today = " Try `jc today`"
+        schedule = "(Full schedule: https://pretalx.com/juliacon2021/schedule)"
+        reply(c, m, not_now * today * "\n\n" * schedule)
     else
-        reply(c, m, "Sorry, are you looking for information on JuliaCon 2021? Please check out `jc help`")
+        reply(c, m, JuliaCon.now(now = current, output=:text))
     end
     return nothing
 end
+
+function jc_execute(c, m, ::Val{:today}, args)
+    day = today(TimeZone(TimeZones.istimezone(args[1]) ? args[1] : "UTC"))
+    return jc_execute(c, m, :day, [day])
+end
+
+function jc_execute(c, m, ::Val{:tomorrow}, args)
+    day = today(TimeZone(TimeZones.istimezone(args[1]) ? args[1] : "UTC")) + Day(1)
+    return jc_execute(c, m, :day, [day])
+end
+
+function jc_execute(c, m, ::Val{:next}, args)
+    @info "Calling :next"
+end
+
+jc_execute(c, m, ::Val{:day}, args) = jc_today(c, m, args[1])
 
 function help_commander(c::Client, m::Message, ::Val{:julia_con})
     reply(c, m, """
@@ -47,18 +78,18 @@ function jc_juliacon2021(c::Client, m::Message)
     return nothing
 end
 
-function jc_now(c::Client, m::Message)
-    if JuliaCon.get_running_talks() === nothing
-        not_now = "There is no JuliaCon program now"
-        @info not_now
-        today = " Try `jc today`"
-        schedule = "(Full schedule: https://pretalx.com/juliacon2021/schedule)"
-        reply(c, m, not_now * today * "\n\n" * schedule)
-    else
-        reply(c, m, JuliaCon.now(output=:text))
-    end
-    return nothing
-end
+# function jc_now(c::Client, m::Message; tz = "UTC")
+#     if JuliaCon.get_running_talks() === nothing
+#         not_now = "There is no JuliaCon program now"
+#         @info not_now
+#         today = " Try `jc today`"
+#         schedule = "(Full schedule: https://pretalx.com/juliacon2021/schedule)"
+#         reply(c, m, not_now * today * "\n\n" * schedule)
+#     else
+#         reply(c, m, JuliaCon.now(output=:text))
+#     end
+#     return nothing
+# end
 
 function split_pretty_table(str)
     lines = split(str, "\n")
@@ -76,15 +107,15 @@ function split_pretty_table(str)
     return strings
 end
 
-function jc_today(c::Client, m::Message)
-    if JuliaCon.get_today() === nothing
+function jc_today(c::Client, m::Message; day = today())
+    if JuliaCon.get_today(now = day) === nothing
         not_today = "There is no JuliaCon program today!"
         @info not_today
         schedule = "(Full schedule: https://pretalx.com/juliacon2021/schedule)"
         reply(c, m, not_today * "\n\n" * schedule)
     else
         strings = Vector{String}()
-        aux = JuliaCon.today(output = :text)
+        aux = JuliaCon.today(now = day, output = :text)
         tables, legend = aux[1:end-1], aux[end]
         for t in tables, str in split_pretty_table(t)
             push!(strings, str)

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,13 +1,3 @@
-# # Package initiation hook
-# function __init__()
-#     # Unfortunately, the default GR backend does not work well with
-#     # offline plotting (see this issue https://github.com/JuliaPlots/Plots.jl/issues/2127).
-#     # So, we will use PyPlot backend instead.
-#     @static if Sys.islinux()
-#         pyplot()
-#     end
-# end
-
 function help_message()
     act_commands = collect(keys(filter(c -> c.second, ACTIVE_COMMANDS)))
     names = collect(values(filter(c -> ACTIVE_COMMANDS[c.first], COMMANDS_NAMES)))


### PR DESCRIPTION
This new PR add the following day schedule request options to the `jc` command
- `jc today|tomorrow [timezone]` tomorrow is a new option. `[timezone]` is optional and needs to comply with TimeZones.jl
- `jc day <xxxx-mm-dd>` speaks for itself

It can be tested on with AzzBot in #juliacon-hq (HoJ) or #azz-bot on the HoJBot test server. I will keep it up until the PR is merged. Please review/merge it asap because JuliaCon has already started ^^

PS: the `next` option is not implemented yet as it is not straightforward to hack JuliaCon.jl. I have left an issue there to see if someone can implement the required methods there.