### PR TITLE
Fix the jc now command

### DIFF
--- a/src/command/jc.jl
+++ b/src/command/jc.jl
@@ -25,7 +25,7 @@ function jc_execute(c, m, ::Val{:now}, args)
     @info "now was required" m.content m.author.username m.author.discriminator args
 
     tz_arg = isempty(args) || !TimeZones.istimezone(args[1]) ? "UTC" : args[1]
-    current = ZonedDateTime(now(tz"UTC"), TimeZone(tz_arg))
+    current = ZonedDateTime(now(), TimeZone(tz_arg))
     # current = ZonedDateTime(Dates.DateTime("2021-07-30T21:30:00.000"), TimeZone(tz_arg))
 
     if isempty(JuliaCon.get_running_talks(now = current))


### PR DESCRIPTION
Sorry, I introduced a bug (that I thought I had fixed) in previous PR. It concerned the `jc now` command

This is the actual fix. It is deployed with Azz-bot in the test server and the juliacon-hq channel in hoj

The sooner merged the better, but we still need @tk3369  to wake up and update the bot anyway.