### PR TITLE
Remove `foobar`, `seam*n` from word filter

### DIFF
--- a/config/mod/bad-words.txt
+++ b/config/mod/bad-words.txt
@@ -264,7 +264,6 @@ fisty
 floozy
 foad
 fondle
-foobar
 foreskin
 freex
 frigg
@@ -563,8 +562,6 @@ scrote
 scrotum
 scrud
 scum
-seaman
-seamen
 seduce
 semen
 shamedame


### PR DESCRIPTION
`foobar` is heavily used in programming along with `foo`, `bar`, `baz`, etc. Nobody uses it instead of the actual curse-containing `fubar`.

`seaman` and `seaman` are both not related to the actual banned word `semen` and its not even slang for it, literally the only time someone would use `seaman` is when talking about the actual profession. I know these two actually don't matter, but I'm still salty from wanting to talk about practical applications of knot theory